### PR TITLE
Added Honey Liquid to forge:honey tag to allow compatibility

### DIFF
--- a/src/generated/resources/data/forge/tags/fluids/honey.json
+++ b/src/generated/resources/data/forge/tags/fluids/honey.json
@@ -1,5 +1,4 @@
 {
-  "replace": false,
   "values": [
     "brewinandchewin:honey"
   ]

--- a/src/main/java/umpaz/brewinandchewin/common/tag/BnCCompatTags.java
+++ b/src/main/java/umpaz/brewinandchewin/common/tag/BnCCompatTags.java
@@ -1,16 +1,27 @@
 package umpaz.brewinandchewin.common.tag;
 
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.FluidTags;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.level.material.Fluid;
 
 public class BnCCompatTags {
 
     public static final TagKey<Item> ORIGINS_IGNORE_DIET = compatItemTag("origins", "ignore_diet");
     public static final TagKey<Item> ORIGINS_MEAT = compatItemTag("origins", "meat");
 
+    public static final TagKey<Fluid> FORGE_HONEY = compatFluidTag("forge", "honey");
+
+
+    private static TagKey<Fluid> compatFluidTag(String namespace, String path){
+        return FluidTags.create(new ResourceLocation(namespace, path));
+    }
+
     private static TagKey<Item> compatItemTag(String namespace, String path) {
         return ItemTags.create(new ResourceLocation(namespace, path));
     }
+
+
 }

--- a/src/main/java/umpaz/brewinandchewin/data/BnCDataGenerators.java
+++ b/src/main/java/umpaz/brewinandchewin/data/BnCDataGenerators.java
@@ -30,6 +30,7 @@ public class BnCDataGenerators {
         BnCBlockTags blockTags = new BnCBlockTags(output, lookupProvider, helper);
         generator.addProvider(event.includeServer(), blockTags);
         generator.addProvider(event.includeServer(), new BnCItemTags(output, lookupProvider, blockTags.contentsGetter(), helper));
+        generator.addProvider(event.includeServer(), new BnCFluidTags(output, lookupProvider, helper));
         generator.addProvider(event.includeServer(), new BnCMobEffectTags(output, lookupProvider, helper));
         generator.addProvider(event.includeServer(), new BnCDamageTypeTags(output, lookupProvider, helper));
         generator.addProvider(event.includeServer(), new BnCRecipes(output));

--- a/src/main/java/umpaz/brewinandchewin/data/BnCFluidTags.java
+++ b/src/main/java/umpaz/brewinandchewin/data/BnCFluidTags.java
@@ -1,0 +1,26 @@
+package umpaz.brewinandchewin.data;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.tags.FluidTagsProvider;
+import net.minecraftforge.common.data.ExistingFileHelper;
+import org.jetbrains.annotations.NotNull;
+import umpaz.brewinandchewin.BrewinAndChewin;
+import umpaz.brewinandchewin.common.registry.BnCFluids;
+import umpaz.brewinandchewin.common.tag.BnCCompatTags;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.CompletableFuture;
+
+public class BnCFluidTags extends FluidTagsProvider {
+    public BnCFluidTags(PackOutput output, CompletableFuture<HolderLookup.Provider> provider, @Nullable ExistingFileHelper existingFileHelper) {
+        super(output, provider, BrewinAndChewin.MODID, existingFileHelper);
+    }
+
+    @Override
+    protected void addTags(HolderLookup.@NotNull Provider provider) {
+        //
+        tag(BnCCompatTags.FORGE_HONEY)
+                .add(BnCFluids.HONEY_FLUID.get());
+    }
+}

--- a/src/main/java/umpaz/brewinandchewin/data/builder/KegFermentingRecipeBuilder.java
+++ b/src/main/java/umpaz/brewinandchewin/data/builder/KegFermentingRecipeBuilder.java
@@ -33,6 +33,7 @@ public class KegFermentingRecipeBuilder {
     private final List<Ingredient> ingredients = Lists.newArrayList();
 
     private Optional<FluidStack> fluidIngredient = Optional.empty();
+
     private Optional<Fluid> resultFluid = Optional.empty();
     private Optional<Item> resultItem = Optional.empty();
     private Optional<FermentingRecipeBookTab> tab = Optional.empty();
@@ -181,6 +182,7 @@ public class KegFermentingRecipeBuilder {
         private final List<Ingredient> ingredients;
         private final Optional<FermentingRecipeBookTab> tab;
         private final Optional<FluidStack> fluidIngredient;
+
         private final Optional<Item> resultItem;
         private final Optional<Fluid> resultFluid;
         private final int fermentingTime;
@@ -194,6 +196,7 @@ public class KegFermentingRecipeBuilder {
         public Result(ResourceLocation idIn, Optional<FluidStack> fluidIngredient, Optional<FermentingRecipeBookTab> tab, Optional<Item> resultItemIn, Optional<Fluid> resultFluidIn, int count, List<Ingredient> ingredientsIn, int fermentingTimeIn, float experienceIn, int temperatureIn, @Nullable Advancement.Builder advancement, @Nullable ResourceLocation advancementId) {
             this.id = idIn;
             this.fluidIngredient = fluidIngredient;
+            //this.fluidIngredientTag = fluidIngredientTag;
             this.tab = tab;
             this.resultItem = resultItemIn;
             this.resultFluid = resultFluidIn;
@@ -218,7 +221,7 @@ public class KegFermentingRecipeBuilder {
             JsonObject result = new JsonObject();
             if (resultItem.isPresent()) {
                 result.addProperty("item", ForgeRegistries.ITEMS.getKey(resultItem.get()).toString());
-            } else {
+            } else if (resultFluid.isPresent()){
                 result.addProperty("fluid", ForgeRegistries.FLUIDS.getKey(resultFluid.get()).toString());
             }
             result.addProperty("count", count);

--- a/src/main/resources/data/forge/tags/fluids/honey.json
+++ b/src/main/resources/data/forge/tags/fluids/honey.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "brewinandchewin:honey"
+  ]
+}


### PR DESCRIPTION
added brewinandchewin:honey to the 'forge:honey' community tag to allow compatibility with other mods (Such as Create)

This allows Honey from Brewin' and Chewin' to be used in recipes from other mods that uses this tag
I Plan to also allow recipes from Brewin' and Chewin' to accept any Honey but that is something I'll do this weekend and if the mod developer doesn't plan that to be possible then it will be just a personal change.