### PR TITLE
Update `pouring/create/builders_tea.json` for Create mod integration

### DIFF
--- a/neoforge/src/main/resources/data/brewinandchewin/recipe/pouring/create/builders_tea.json
+++ b/neoforge/src/main/resources/data/brewinandchewin/recipe/pouring/create/builders_tea.json
@@ -10,15 +10,13 @@
   },
   "output": {
     "count": 1,
-    "id": "create:buiders_tea"
+    "id": "create:builders_tea"
   },
   "strict": false,
   "fabric:load_conditions": [
     {
       "condition": "fabric:all_mods_loaded",
-      "namespaces": [
-        "create"
-      ]
+      "namespaces": ["create"]
     }
   ],
   "neoforge:conditions": [


### PR DESCRIPTION
Fixed typo in create integration recipe.

Fixes this error:
```log
[Render thread/ERROR] [net.minecraft.world.item.crafting.RecipeManager/]: Parsing error loading recipe brewinandchewin:pouring/create/builders_tea: com.google.gson.JsonParseException: Unknown registry key in ResourceKey[minecraft:root / minecraft:item]: create:buiders_tea
```