### PR TITLE
Fix Coaster missing proper footstep sounds

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/block/combination_step_sound_blocks.json
+++ b/common/src/main/resources/data/minecraft/tags/block/combination_step_sound_blocks.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "brewinandchewin:coaster"
+  ]
+}


### PR DESCRIPTION
When stepping onto a Coaster, the sound that plays is of the block underneath. This PR adds this block to the proper tag to fix it, akin to carpets.

Similar to https://github.com/vectorwing/FarmersDelight/pull/1246 and https://github.com/MehVahdJukaar/Supplementaries/pull/1922

The tag also exists in 1.20 so this can be cherrypicked.