### PR TITLE
Band-aid fix for NullPointerException in tick with FD 1.3.1

### DIFF
--- a/common/src/main/java/umpaz/brewinandchewin/common/block/entity/KegBlockEntity.java
+++ b/common/src/main/java/umpaz/brewinandchewin/common/block/entity/KegBlockEntity.java
@@ -498,13 +498,35 @@ public class KegBlockEntity extends SyncedBlockEntity implements MenuProvider, N
             }
         }
 
-        int heat = states.stream().filter(s -> s.is(ModTags.HEAT_SOURCES) && s.hasProperty(BlockStateProperties.LIT)).filter(s -> s.getValue(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
-        heat += states.stream().filter(s -> s.is(ModTags.HEAT_SOURCES) && !s.hasProperty(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
-
+        int heat = 0;
+        try {
+            heat += states.stream().filter(s -> s.is(ModTags.HEAT_SOURCES) && s.hasProperty(BlockStateProperties.LIT)).filter(s -> s.getValue(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
+        }
+        catch(NullPointerException e) {
+            heat += 0;
+        }
+        try {
+            heat += states.stream().filter(s -> s.is(ModTags.HEAT_SOURCES) && !s.hasProperty(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
+        }
+        catch(NullPointerException e) {
+            heat += 0;
+        }
+        
         // Compat with mods that have lit states, such as a future Pug FD addon.
-        int cold = states.stream().filter(s -> s.is(BnCTags.Blocks.FREEZE_SOURCES) && s.hasProperty(BlockStateProperties.LIT)).filter(s -> s.hasProperty(BlockStateProperties.LIT)).filter(s -> s.getValue(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
-        cold += states.stream().filter(s -> s.is(BnCTags.Blocks.FREEZE_SOURCES) && !s.hasProperty(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
-
+        int cold = 0;
+        try {
+            cold = states.stream().filter(s -> s.is(BnCTags.Blocks.FREEZE_SOURCES) && s.hasProperty(BlockStateProperties.LIT)).filter(s -> s.hasProperty(BlockStateProperties.LIT)).filter(s -> s.getValue(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
+        }
+        catch(NullPointerException e) {
+            cold += 0;
+        }
+        try {
+             cold += states.stream().filter(s -> s.is(BnCTags.Blocks.FREEZE_SOURCES) && !s.hasProperty(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
+        }
+        catch(NullPointerException e) {
+            cold += 0;
+        }
+        
         if (BnCConfiguration.COMMON_CONFIG.get().keg().biomeTemp()) {
             Holder<Biome> biome = level.getBiome(worldPosition);
             if (biome.isBound()) {

--- a/common/src/main/java/umpaz/brewinandchewin/common/block/entity/KegBlockEntity.java
+++ b/common/src/main/java/umpaz/brewinandchewin/common/block/entity/KegBlockEntity.java
@@ -489,22 +489,47 @@ public class KegBlockEntity extends SyncedBlockEntity implements MenuProvider, N
     }
 
     public void updateTemperature() {
-        ArrayList<BlockState> states = new ArrayList<>();
-        for (int x = -RANGE; x <= RANGE; x++) {
-            for (int y = -RANGE; y <= RANGE; y++) {
-                for (int z = -RANGE; z <= RANGE; z++) {
-                    states.add(level.getBlockState(worldPosition.offset(x, y, z)));
+        ArrayList<BlockState> states = new ArrayList<BlockState>();
+        if(level != null) {
+            for (int x = -RANGE; x <= RANGE; x++) {
+                for (int y = -RANGE; y <= RANGE; y++) {
+                    for (int z = -RANGE; z <= RANGE; z++) {
+                        states.add(level.getBlockState(worldPosition.offset(x, y, z)));
+                    }
                 }
             }
         }
+        
 
-        int heat = states.stream().filter(s -> s.is(ModTags.HEAT_SOURCES) && s.hasProperty(BlockStateProperties.LIT)).filter(s -> s.getValue(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
-        heat += states.stream().filter(s -> s.is(ModTags.HEAT_SOURCES) && !s.hasProperty(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
-
+        int heat = 0;
+        try {
+            heat += states.stream().filter(s -> s.is(ModTags.HEAT_SOURCES) && s.hasProperty(BlockStateProperties.LIT)).filter(s -> s.getValue(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
+        }
+        catch(NullPointerException e) {
+            heat += 0;
+        }
+        try {
+            heat += states.stream().filter(s -> s.is(ModTags.HEAT_SOURCES) && !s.hasProperty(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
+        }
+        catch(NullPointerException e) {
+            heat += 0;
+        }
+        
         // Compat with mods that have lit states, such as a future Pug FD addon.
-        int cold = states.stream().filter(s -> s.is(BnCTags.Blocks.FREEZE_SOURCES) && s.hasProperty(BlockStateProperties.LIT)).filter(s -> s.hasProperty(BlockStateProperties.LIT)).filter(s -> s.getValue(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
-        cold += states.stream().filter(s -> s.is(BnCTags.Blocks.FREEZE_SOURCES) && !s.hasProperty(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
-
+        int cold = 0;
+        try {
+            cold = states.stream().filter(s -> s.is(BnCTags.Blocks.FREEZE_SOURCES) && s.hasProperty(BlockStateProperties.LIT)).filter(s -> s.hasProperty(BlockStateProperties.LIT)).filter(s -> s.getValue(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
+        }
+        catch(NullPointerException e) {
+            cold += 0;
+        }
+        try {
+             cold += states.stream().filter(s -> s.is(BnCTags.Blocks.FREEZE_SOURCES) && !s.hasProperty(BlockStateProperties.LIT)).mapToInt(s -> 1).sum();
+        }
+        catch(NullPointerException e) {
+            cold += 0;
+        }
+        
         if (BnCConfiguration.COMMON_CONFIG.get().keg().biomeTemp()) {
             Holder<Biome> biome = level.getBiome(worldPosition);
             if (biome.isBound()) {


### PR DESCRIPTION
This doesn't treat the root cause, but it should have the same net result as treating the root cause: one assumes that the filter resolving as null means that there weren't any appropriate blocks within range.

Somebody with more knowledge than me about Neoforge, Create, and/or FD can probably figure out where exactly in the chain we've lost track of HEAT_SOURCES and/or LIT.